### PR TITLE
fix sidebar UX: accessibility, focus management, reduced motion

### DIFF
--- a/bristlenose/theme/organisms/sidebar.css
+++ b/bristlenose/theme/organisms/sidebar.css
@@ -53,6 +53,10 @@
     transition: grid-template-columns 0.25s ease;
 }
 
+@media (prefers-reduced-motion: reduce) {
+    .layout.animating { transition: none; }
+}
+
 /* ── Column 1: Left icon rail ─────────────────────────────────── */
 
 .toc-rail {
@@ -86,6 +90,11 @@
 .rail-btn:hover {
     background: var(--bn-colour-hover);
     color: var(--bn-colour-accent);
+}
+
+.rail-btn:focus-visible {
+    outline: 2px solid var(--bn-colour-accent);
+    outline-offset: -2px;
 }
 
 /* ── Column 2: Left sidebar (TOC) ────────────────────────────── */
@@ -136,6 +145,11 @@
 
 .sidebar-close:hover { color: var(--bn-colour-text); }
 
+.sidebar-close:focus-visible {
+    outline: 2px solid var(--bn-colour-accent);
+    outline-offset: -2px;
+}
+
 .toc-sidebar-body {
     flex: 1;
     overflow-y: auto;
@@ -171,6 +185,11 @@
     text-decoration: underline;
     text-underline-offset: 0.25em;
     text-decoration-color: var(--bn-colour-accent);
+}
+
+.toc-link:focus-visible {
+    outline: 2px solid var(--bn-colour-accent);
+    outline-offset: -2px;
 }
 
 .toc-link.active {
@@ -289,6 +308,11 @@
 .drag-handle.active {
     background: var(--bn-colour-accent);
     opacity: 0.3;
+}
+
+.drag-handle:focus-visible {
+    outline: 2px solid var(--bn-colour-accent);
+    outline-offset: -2px;
 }
 
 .drag-handle::after {

--- a/frontend/src/components/SidebarLayout.test.tsx
+++ b/frontend/src/components/SidebarLayout.test.tsx
@@ -18,8 +18,15 @@ vi.mock("./TagSidebar", () => ({
 
 // Mock useDragResize to avoid pointer event complexity in layout tests.
 const mockHandlePointerDown = vi.fn();
+const mockHandleKeyDown = vi.fn();
 vi.mock("../hooks/useDragResize", () => ({
-  useDragResize: () => ({ handlePointerDown: mockHandlePointerDown, isDragging: false }),
+  useDragResize: () => ({
+    handlePointerDown: mockHandlePointerDown,
+    handleKeyDown: mockHandleKeyDown,
+    isDragging: false,
+  }),
+  MIN_WIDTH: 200,
+  MAX_WIDTH: 320,
 }));
 
 // Mock SidebarStore — we control state via mockState.

--- a/frontend/src/components/SidebarLayout.tsx
+++ b/frontend/src/components/SidebarLayout.tsx
@@ -13,7 +13,7 @@
  * @module SidebarLayout
  */
 
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import {
   useSidebarStore,
   toggleToc,
@@ -23,14 +23,14 @@ import {
 } from "../contexts/SidebarStore";
 import { TocSidebar } from "./TocSidebar";
 import { TagSidebar } from "./TagSidebar";
-import { useDragResize } from "../hooks/useDragResize";
+import { useDragResize, MIN_WIDTH, MAX_WIDTH } from "../hooks/useDragResize";
 
 // ── SVG icons (inline, 18×18) ─────────────────────────────────────────────
 
 /** List icon — for TOC rail button */
 function ListIcon() {
   return (
-    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden="true" focusable="false">
       <line x1="5.5" y1="4.5" x2="14" y2="4.5" />
       <line x1="5.5" y1="9" x2="14" y2="9" />
       <line x1="5.5" y1="13.5" x2="14" y2="13.5" />
@@ -44,7 +44,7 @@ function ListIcon() {
 /** Tag icon — for tag rail button */
 function TagIcon() {
   return (
-    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" focusable="false">
       <path d="M2.5 3.5h5l7 7-5 5-7-7z" />
       <circle cx="6" cy="7" r="0.75" fill="currentColor" stroke="none" />
     </svg>
@@ -95,6 +95,14 @@ interface SidebarLayoutProps {
 export function SidebarLayout({ active, children }: SidebarLayoutProps) {
   const { tocOpen, tagsOpen, tocWidth, tagsWidth } = useSidebarStore();
   const layoutRef = useRef<HTMLDivElement>(null);
+  const tocRailBtnRef = useRef<HTMLButtonElement>(null);
+  const tagRailBtnRef = useRef<HTMLButtonElement>(null);
+  const tocSidebarRef = useRef<HTMLDivElement>(null);
+  const tagSidebarRef = useRef<HTMLDivElement>(null);
+
+  // Track previous open state for focus management.
+  const prevTocOpen = useRef(tocOpen);
+  const prevTagsOpen = useRef(tagsOpen);
 
   // Drag-to-resize handles (4 total).
   const tocEdge = useDragResize({
@@ -126,6 +134,57 @@ export function SidebarLayout({ active, children }: SidebarLayoutProps) {
     withAnimation(layoutRef.current, closeTags);
   }, []);
 
+  // Focus management: move focus when sidebars open/close.
+  useEffect(() => {
+    if (prevTocOpen.current !== tocOpen) {
+      if (tocOpen) {
+        // Just opened — focus first interactive element in sidebar.
+        const target = tocSidebarRef.current?.querySelector<HTMLElement>(
+          ".sidebar-close, .toc-link",
+        );
+        target?.focus();
+      } else {
+        // Just closed — return focus to rail button.
+        tocRailBtnRef.current?.focus();
+      }
+      prevTocOpen.current = tocOpen;
+    }
+  }, [tocOpen]);
+
+  useEffect(() => {
+    if (prevTagsOpen.current !== tagsOpen) {
+      if (tagsOpen) {
+        const target = tagSidebarRef.current?.querySelector<HTMLElement>(
+          ".sidebar-close",
+        );
+        target?.focus();
+      } else {
+        tagRailBtnRef.current?.focus();
+      }
+      prevTagsOpen.current = tagsOpen;
+    }
+  }, [tagsOpen]);
+
+  // Escape key: close the sidebar that contains focus.
+  useEffect(() => {
+    if (!active) return;
+
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      const target = e.target as Node | null;
+      if (tocOpen && tocSidebarRef.current?.contains(target)) {
+        e.preventDefault();
+        handleCloseToc();
+      } else if (tagsOpen && tagSidebarRef.current?.contains(target)) {
+        e.preventDefault();
+        handleCloseTags();
+      }
+    };
+
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [active, tocOpen, tagsOpen, handleCloseToc, handleCloseTags]);
+
   if (!active) {
     return <>{children}</>;
   }
@@ -143,6 +202,7 @@ export function SidebarLayout({ active, children }: SidebarLayoutProps) {
       {/* Column 1: TOC rail (visible when TOC sidebar is closed) */}
       <div className="toc-rail">
         <button
+          ref={tocRailBtnRef}
           className="rail-btn"
           onClick={handleToggleToc}
           title="Table of contents ( [ )"
@@ -159,7 +219,11 @@ export function SidebarLayout({ active, children }: SidebarLayoutProps) {
       </div>
 
       {/* Column 2: TOC sidebar panel */}
-      <div className="toc-sidebar">
+      <div
+        ref={tocSidebarRef}
+        className="toc-sidebar"
+        inert={!tocOpen ? true : undefined}
+      >
         <div className="toc-sidebar-header">
           <span className="sidebar-title">Contents</span>
           <button
@@ -177,7 +241,15 @@ export function SidebarLayout({ active, children }: SidebarLayoutProps) {
         {tocOpen && (
           <div
             className={`drag-handle toc-drag-handle${tocEdge.isDragging ? " active" : ""}`}
+            role="separator"
+            aria-orientation="vertical"
+            aria-valuenow={tocWidth}
+            aria-valuemin={MIN_WIDTH}
+            aria-valuemax={MAX_WIDTH}
+            aria-label="Resize table of contents"
+            tabIndex={0}
             onPointerDown={tocEdge.handlePointerDown}
+            onKeyDown={tocEdge.handleKeyDown}
           />
         )}
       </div>
@@ -188,7 +260,11 @@ export function SidebarLayout({ active, children }: SidebarLayoutProps) {
       </div>
 
       {/* Column 4: Tag sidebar panel */}
-      <div className="tag-sidebar">
+      <div
+        ref={tagSidebarRef}
+        className="tag-sidebar"
+        inert={!tagsOpen ? true : undefined}
+      >
         <div className="tag-sidebar-header">
           <span className="sidebar-title">Tags</span>
           <button
@@ -204,7 +280,15 @@ export function SidebarLayout({ active, children }: SidebarLayoutProps) {
         {tagsOpen && (
           <div
             className={`drag-handle tag-drag-handle${tagEdge.isDragging ? " active" : ""}`}
+            role="separator"
+            aria-orientation="vertical"
+            aria-valuenow={tagsWidth}
+            aria-valuemin={MIN_WIDTH}
+            aria-valuemax={MAX_WIDTH}
+            aria-label="Resize tag sidebar"
+            tabIndex={0}
             onPointerDown={tagEdge.handlePointerDown}
+            onKeyDown={tagEdge.handleKeyDown}
           />
         )}
       </div>
@@ -212,6 +296,7 @@ export function SidebarLayout({ active, children }: SidebarLayoutProps) {
       {/* Column 5: Tag rail (visible when tag sidebar is closed) */}
       <div className="tag-rail">
         <button
+          ref={tagRailBtnRef}
           className="rail-btn"
           onClick={handleToggleTags}
           title="Tags ( ] )"

--- a/frontend/src/components/TocSidebar.tsx
+++ b/frontend/src/components/TocSidebar.tsx
@@ -79,28 +79,27 @@ export function TocSidebar() {
     }));
   }, [data]);
 
-  // All IDs for scroll spy (in DOM order: sections heading, sections, themes heading, themes).
+  // All IDs for scroll spy — only actual link targets, not group headings.
+  // Group headings ("sections", "themes") are excluded because the scroll spy
+  // would set activeId to a heading with no corresponding link, causing a
+  // brief gap where nothing in the sidebar is highlighted.
   const allIds = useMemo(() => {
     const ids: string[] = [];
-    if (sections.length > 0) {
-      ids.push("sections");
-      ids.push(...sections.map((s) => s.id));
-    }
-    if (themes.length > 0) {
-      ids.push("themes");
-      ids.push(...themes.map((t) => t.id));
-    }
+    ids.push(...sections.map((s) => s.id));
+    ids.push(...themes.map((t) => t.id));
     return ids;
   }, [sections, themes]);
 
   const activeId = useScrollSpy(allIds);
 
   // Auto-scroll active TOC link into view within the sidebar.
+  // Uses "instant" (not "smooth") to avoid competing scrollIntoView calls
+  // when activeId changes rapidly during fast scrolling.
   useEffect(() => {
     if (activeRef.current) {
       activeRef.current.scrollIntoView({
         block: "nearest",
-        behavior: "smooth",
+        behavior: "instant",
       });
     }
   }, [activeId]);
@@ -117,7 +116,7 @@ export function TocSidebar() {
   if (!data) return null;
 
   return (
-    <>
+    <nav aria-label="Table of contents">
       {sections.length > 0 && (
         <>
           <div className="toc-heading">Sections</div>
@@ -126,6 +125,7 @@ export function TocSidebar() {
               key={entry.id}
               href={`#${entry.id}`}
               className={`toc-link${activeId === entry.id ? " active" : ""}`}
+              aria-current={activeId === entry.id ? "location" : undefined}
               ref={activeId === entry.id ? activeRef : undefined}
               onClick={(e) => handleClick(e, entry.id)}
             >
@@ -142,6 +142,7 @@ export function TocSidebar() {
               key={entry.id}
               href={`#${entry.id}`}
               className={`toc-link${activeId === entry.id ? " active" : ""}`}
+              aria-current={activeId === entry.id ? "location" : undefined}
               ref={activeId === entry.id ? activeRef : undefined}
               onClick={(e) => handleClick(e, entry.id)}
             >
@@ -150,6 +151,6 @@ export function TocSidebar() {
           ))}
         </>
       )}
-    </>
+    </nav>
   );
 }

--- a/frontend/src/hooks/useDragResize.ts
+++ b/frontend/src/hooks/useDragResize.ts
@@ -23,10 +23,11 @@ import {
 
 // ── Constants ────────────────────────────────────────────────────────────
 
-const MIN_WIDTH = 200;
-const MAX_WIDTH = 320;
+export const MIN_WIDTH = 200;
+export const MAX_WIDTH = 320;
 const SNAP_CLOSE_THRESHOLD = 80;
 const RAIL_OPEN_THRESHOLD = 20;
+const RESIZE_STEP = 10;
 
 // ── Types ────────────────────────────────────────────────────────────────
 
@@ -44,6 +45,8 @@ export interface UseDragResizeOptions {
 export interface UseDragResizeReturn {
   /** Attach to the drag handle div's onPointerDown. */
   handlePointerDown: (e: React.PointerEvent) => void;
+  /** Attach to the drag handle div's onKeyDown for keyboard resize. */
+  handleKeyDown: (e: React.KeyboardEvent) => void;
   /** Whether this handle is actively being dragged (for `.active` class). */
   isDragging: boolean;
 }
@@ -166,6 +169,37 @@ export function useDragResize({
     [side, source, layoutRef, cssVar, openFn, closeFn, setWidthFn],
   );
 
+  // Keyboard resize for sidebar edge handles (arrow keys ±10px, Home/End for min/max).
+  // Rail handles use the toggle button for keyboard access instead.
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (source !== "sidebar") return;
+
+      // For TOC (left sidebar): ArrowRight = wider, ArrowLeft = narrower.
+      // For Tags (right sidebar): ArrowLeft = wider, ArrowRight = narrower.
+      const increaseKey = side === "toc" ? "ArrowRight" : "ArrowLeft";
+      const decreaseKey = side === "toc" ? "ArrowLeft" : "ArrowRight";
+
+      let newWidth: number | null = null;
+
+      if (e.key === increaseKey) {
+        newWidth = Math.min(MAX_WIDTH, currentWidthRef.current + RESIZE_STEP);
+      } else if (e.key === decreaseKey) {
+        newWidth = Math.max(MIN_WIDTH, currentWidthRef.current - RESIZE_STEP);
+      } else if (e.key === "Home") {
+        newWidth = MIN_WIDTH;
+      } else if (e.key === "End") {
+        newWidth = MAX_WIDTH;
+      }
+
+      if (newWidth !== null) {
+        e.preventDefault();
+        setWidthFn(newWidth);
+      }
+    },
+    [side, source, setWidthFn],
+  );
+
   // Cleanup on unmount if drag is in progress.
   useEffect(() => {
     return () => {
@@ -173,5 +207,5 @@ export function useDragResize({
     };
   }, []);
 
-  return { handlePointerDown, isDragging };
+  return { handlePointerDown, handleKeyDown, isDragging };
 }


### PR DESCRIPTION
High-priority fixes:
- Add aria-current="location" on active TOC link
- Wrap TocSidebar in <nav> landmark with aria-label
- Add keyboard resize to drag handles (role="separator", arrow keys)
- Add inert on closed sidebar panels (removes from tab order)
- Add focus management on open/close (focus sidebar on open, return to rail button on close)

Medium-priority fixes:
- Fix scrollIntoView jank (behavior: "instant" instead of "smooth")
- Remove group heading IDs from scroll spy (prevents highlight gap)
- Add prefers-reduced-motion override for grid animation
- Add Escape key to close sidebar containing focus
- Add aria-hidden + focusable="false" on SVG icons
- Add :focus-visible rings on rail buttons, TOC links, close buttons, and drag handles

https://claude.ai/code/session_015nqhiDHf9oKoJ62xpT9Nxn