### PR TITLE
desktop: redirect bundled sidecar TLS to certifi under sandbox

### DIFF
--- a/desktop/Bristlenose/Bristlenose/BristlenoseShared.swift
+++ b/desktop/Bristlenose/Bristlenose/BristlenoseShared.swift
@@ -32,6 +32,37 @@ enum BristlenoseShared {
         )
     }
 
+    /// SSL/TLS environment overrides for the bundled sidecar's Python OpenSSL.
+    ///
+    /// PyInstaller's bundled Python has compile-time OpenSSL defaults pointing
+    /// at the build machine's Homebrew paths (`/opt/homebrew/etc/openssl@3/
+    /// openssl.cnf` + `/opt/homebrew/etc/ca-certificates/cert.pem`). Under
+    /// macOS App Sandbox those paths are blocked → silent TLS init failure →
+    /// every outbound HTTPS call (Anthropic, HuggingFace, OpenAI) errors out
+    /// before stage 5 even reads its cache. See
+    /// `docs/private/sandbox-violations-A1c.md` row 4.
+    ///
+    /// Fix: point Python at certifi's CA bundle (shipped by PyInstaller at
+    /// `_internal/certifi/cacert.pem` next to the binary) and at `/dev/null`
+    /// for `OPENSSL_CONF` so OpenSSL doesn't probe the missing system config.
+    ///
+    /// Returns an empty dict for non-bundled modes — dev sidecar / external
+    /// both run outside the app bundle, against whatever OpenSSL their host
+    /// Python was linked against.
+    static func sslEnvironment(for mode: SidecarMode) -> [String: String] {
+        guard case let .bundled(binaryURL) = mode else { return [:] }
+        let certifiDir = binaryURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("_internal/certifi")
+        let cacert = certifiDir.appendingPathComponent("cacert.pem").path
+        return [
+            "SSL_CERT_FILE": cacert,
+            "SSL_CERT_DIR": certifiDir.path,
+            "REQUESTS_CA_BUNDLE": cacert,
+            "OPENSSL_CONF": "/dev/null"
+        ]
+    }
+
     /// Build the minimal environment for a `bristlenose` subprocess.
     /// Inherits only the handful of vars the CLI needs; avoids leaking
     /// credentials, DYLD_* vars, Xcode debug vars, etc. API keys are read

--- a/desktop/Bristlenose/Bristlenose/PipelineRunner.swift
+++ b/desktop/Bristlenose/Bristlenose/PipelineRunner.swift
@@ -891,6 +891,7 @@ final class PipelineRunner: ObservableObject {
         // both surface as `.failed` state on the project so the GUI shows
         // something actionable.
         let binary: URL
+        let resolvedMode: SidecarMode
         #if DEBUG
         let externalPortRaw = ProcessInfo.processInfo.environment["BRISTLENOSE_DEV_EXTERNAL_PORT"]
         let sidecarPathRaw = ProcessInfo.processInfo.environment["BRISTLENOSE_DEV_SIDECAR_PATH"]
@@ -913,6 +914,7 @@ final class PipelineRunner: ObservableObject {
             switch mode {
             case .bundled(let path), .devSidecar(let path):
                 binary = path
+                resolvedMode = mode
                 Self.logger.info(
                     "spawn binary resolved: \(mode.logDescription, privacy: .public) project=\(project.id.uuidString, privacy: .public)"
                 )
@@ -958,6 +960,12 @@ final class PipelineRunner: ObservableObject {
         // it's the only access control pre-A1c.
         var env = BristlenoseShared.buildChildEnvironment()
         env["_BRISTLENOSE_HOSTED_BY_DESKTOP"] = "1"
+        // Bundled-sidecar TLS fix — see BristlenoseShared.sslEnvironment(for:).
+        // Without this, PyInstaller's OpenSSL probes Homebrew paths blocked
+        // by App Sandbox → all HTTPS-out fails (A1c row 4).
+        for (key, value) in BristlenoseShared.sslEnvironment(for: resolvedMode) {
+            env[key] = value
+        }
         proc.environment = env
 
         let pipe = Pipe()

--- a/desktop/Bristlenose/Bristlenose/ServeManager.swift
+++ b/desktop/Bristlenose/Bristlenose/ServeManager.swift
@@ -174,6 +174,12 @@ final class ServeManager: ObservableObject {
         // of leaving an orphan holding a port). CLI users don't get this
         // — they may legitimately nohup the server.
         env["_BRISTLENOSE_HOSTED_BY_DESKTOP"] = "1"
+        // Bundled-sidecar TLS fix — see BristlenoseShared.sslEnvironment(for:).
+        // Without this, PyInstaller's OpenSSL probes Homebrew paths blocked
+        // by App Sandbox → all HTTPS-out fails (A1c row 4).
+        for (key, value) in BristlenoseShared.sslEnvironment(for: mode) {
+            env[key] = value
+        }
         Self.overlayPreferences(into: &env)
         Self.overlayAPIKeys(into: &env, using: KeychainHelper.liveStore)
         proc.environment = env

--- a/desktop/Bristlenose/BristlenoseTests/SslEnvironmentTests.swift
+++ b/desktop/Bristlenose/BristlenoseTests/SslEnvironmentTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+@testable import Bristlenose
+
+/// Tests for BristlenoseShared.sslEnvironment(for:) — bundled-sidecar TLS
+/// fix. See `docs/private/sandbox-violations-A1c.md` row 4 for context:
+/// PyInstaller's bundled Python OpenSSL has compile-time defaults pointing
+/// at Homebrew paths blocked by App Sandbox; this helper redirects to
+/// certifi's bundled CA file.
+@Suite("BristlenoseShared.sslEnvironment")
+struct SslEnvironmentTests {
+
+    @Test func bundled_mode_emits_four_ssl_vars() {
+        let binary = URL(fileURLWithPath: "/tmp/Bristlenose.app/Contents/Resources/bristlenose-sidecar/bristlenose-sidecar")
+        let env = BristlenoseShared.sslEnvironment(for: .bundled(path: binary))
+
+        let expectedCert = "/tmp/Bristlenose.app/Contents/Resources/bristlenose-sidecar/_internal/certifi/cacert.pem"
+        let expectedDir = "/tmp/Bristlenose.app/Contents/Resources/bristlenose-sidecar/_internal/certifi"
+
+        #expect(env["SSL_CERT_FILE"] == expectedCert)
+        #expect(env["SSL_CERT_DIR"] == expectedDir)
+        #expect(env["REQUESTS_CA_BUNDLE"] == expectedCert)
+        #expect(env["OPENSSL_CONF"] == "/dev/null")
+        #expect(env.count == 4)
+    }
+
+    @Test func dev_sidecar_mode_emits_nothing() {
+        // Dev sidecar runs against the developer's venv Python — its OpenSSL
+        // is whatever Homebrew/system paths point at, which work fine outside
+        // App Sandbox. Don't override.
+        let binary = URL(fileURLWithPath: "/Users/dev/.venv/bin/bristlenose")
+        let env = BristlenoseShared.sslEnvironment(for: .devSidecar(path: binary))
+
+        #expect(env.isEmpty)
+    }
+
+    @Test func external_mode_emits_nothing() {
+        // External mode never spawns a subprocess — the host process talks
+        // to an already-running serve. No env to set.
+        let env = BristlenoseShared.sslEnvironment(for: .external(port: 9131))
+
+        #expect(env.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `BristlenoseShared.sslEnvironment(for:)` — a 4-env-var override (`SSL_CERT_FILE`, `SSL_CERT_DIR`, `REQUESTS_CA_BUNDLE`, `OPENSSL_CONF`) that points the bundled sidecar's PyInstaller'd Python at certifi's CA bundle inside the `.app`, instead of the Homebrew paths its OpenSSL was compile-time-defaulted to.
- Wires it into `PipelineRunner.spawn()` and `ServeManager.start()` next to the existing `_BRISTLENOSE_HOSTED_BY_DESKTOP=1` host-gate.
- New `SslEnvironmentTests.swift` covers bundled (4 vars set, paths correct), devSidecar (empty), external (empty).

## Why

A1c sandbox-violation walk found bundled OpenSSL probing `/opt/homebrew/etc/openssl@3/openssl.cnf` and `cert.pem` — both blocked by macOS App Sandbox. OpenSSL silently degrades; every outbound HTTPS (Anthropic, HuggingFace, OpenAI) dies inside `_ssl.c:1010` at handshake before stage 5's cache check runs. Beats 6, 7, 9, 10, 11 all unreachable. This was the dominant blocker.

## Verification

Live walk on a sandboxed Debug build (`bundled-tls-config · 54b5dc7-dirty · sandbox=on`):

- `ps eww <sidecar-pid>` confirms all four env vars present, paths point at the `.app`-bundled certifi.
- Kernel logs (`log stream --predicate '(Sandbox) AND eventMessage CONTAINS "bristlenose"'`) — zero `deny(1) file-read-data /opt/homebrew/etc/openssl@3/*` lines (vs many pre-fix).
- Doctor's API-key HTTPS round-trip now reaches Anthropic and gets a real `401` response (key revoked) — was previously `[SSL: CERTIFICATE_VERIFY_FAILED] _ssl.c:1010` at handshake.
- Pipeline run on `foobar` (cached) ingests + re-renders cleanly; serve sidecar imports project.

## Notes

- Only `.bundled` mode gets the override. Dev-sidecar runs against the developer's host Python (homebrew-linked, sandbox-off, normal OpenSSL); external mode never spawns. Empty dict for both.
- `BristlenoseTests` target isn't yet wired into the Xcode scheme (per the existing comment in `ServeManagerEnvTests.swift`). The new test file follows the same aspirational-pattern convention; will execute once the test target lands.
- Doesn't touch the next predicted blocker — `bundled-binary-helper` for `ffmpeg`/`ffprobe` (PATH stripped under sandbox). That's the next narrow branch per the A1c ordering.

## Test plan

- [x] Sandboxed Debug build launches cleanly (no `network-bind` deny, no SSL deny)
- [x] Env vars present on live sidecar process
- [x] Pipeline run on cached project completes
- [x] Doctor API-key check reaches Anthropic (real 401 vs SSL handshake failure)
- [ ] Fresh project run end-to-end — gated on `bundled-binary-helper` (next branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)